### PR TITLE
Add 0xcert crowdsale contract

### DIFF
--- a/contracts/crowdsale/XctCrowdsale.sol
+++ b/contracts/crowdsale/XctCrowdsale.sol
@@ -127,9 +127,8 @@ contract XctCrowdsale is Ownable {
 
     weiRaised = weiRaised.add(weiAmount);
 
-    if (!token.transferFrom(token.owner(), beneficiary, tokens)) {
-      revert();
-    }
+    require(token.transferFrom(token.owner(), beneficiary, tokens));
+
     TokenPurchase(msg.sender, beneficiary, weiAmount, tokens);
 
     forwardFunds();

--- a/contracts/crowdsale/XctCrowdsale.sol
+++ b/contracts/crowdsale/XctCrowdsale.sol
@@ -1,0 +1,197 @@
+pragma solidity ^0.4.19;
+
+import "../math/SafeMath.sol";
+import "../tokens/Xct.sol";
+import "../ownership/Ownable.sol";
+
+
+/**
+ * @title XCT crowdsale contract.
+ * @dev Crowdsale contract for distributing XCT token.
+ */
+contract XctCrowdsale is Ownable {
+  using SafeMath for uint256;
+
+  /**
+   * Token being sold.
+   */
+  Xct public token;
+
+  /**
+   * Start timestamps for when investments are allowed (both inclusive).
+   * First stage:
+   *   - first 24 hours with a personal cap
+   * Second stage:
+   *   - after 24 hours and lasts for 7 days without a personal cap
+   */
+  uint256 public startTimeStageOne;
+
+  uint256 public startTimeStageTwo;
+
+  /**
+   * End timestamp to end the crowdsale.
+   */
+  uint256 public endTime;
+
+  /**
+   * Maximum amount of wei to spend during the first stage of the crowdsale.
+   */
+  uint256 public personalWeiCap;
+
+  /**
+   * Crowdsale cap in wei.
+   */
+  uint256 public crowdSaleWeiCap;
+  /**
+   * Raised amount in wei.
+   */
+  uint256 public weiRaised;
+
+  /**
+   * Address where funds are collected.
+   */
+  address public wallet;
+
+  /**
+   * How many token units a buyer gets per wei.
+   */
+  uint256 public rate;
+
+  /**
+   * @dev An event which is triggered when tokens are bought.
+   * @param _from The address sending tokens.
+   * @param _to The address recieving tokens.
+   * @param _weiAmount Purchase amount in wei.
+   * @param _tokenAmount The amount of purchased tokens.
+   */
+  event TokenPurchase(address indexed _from, address indexed _to, uint256 _weiAmount,
+                      uint256 _tokenAmount);
+
+  /**
+   * @dev Contract constructor.
+   */
+  function XctCrowdsale(uint256 _startTimeStageOne,
+                        uint256 _personalWeiCap,
+                        uint256 _crowdSaleWeiCap,
+                        uint256 _rate,
+                        address _walletAddress,
+                        address _tokenAddress)
+    public
+  {
+    require(_startTimeStageOne >= now);
+    require(_crowdSaleWeiCap > 0);
+    require(_personalWeiCap > 0);
+    require(_personalWeiCap < _crowdSaleWeiCap);
+    require(_rate > 0);
+    require(_walletAddress != address(0));
+    require(_tokenAddress != address(0));
+    require(_tokenAddress != _walletAddress);
+
+    token = Xct(_tokenAddress);
+    require(token.totalSupply() >= _crowdSaleWeiCap.mul(_rate));
+
+    startTimeStageOne = _startTimeStageOne;
+    startTimeStageTwo = _startTimeStageOne + 1 days;
+    endTime = startTimeStageTwo + 7 days;
+    personalWeiCap = _personalWeiCap;
+    crowdSaleWeiCap = _crowdSaleWeiCap;
+    rate = _rate;
+    wallet = _walletAddress;
+  }
+
+  /**
+   * @dev Fallback function can be used to buy tokens.
+   */
+  function()
+    external
+    payable
+  {
+    buyTokens(msg.sender);
+  }
+
+  /**
+   * @dev Low level token purchase function.
+   * @param beneficiary Address which is buying tokens.
+   */
+  function buyTokens(address beneficiary)
+    public
+    payable
+  {
+    require(beneficiary != address(0));
+    require(validPurchase(msg.value));
+
+    uint256 weiAmount = msg.value;
+
+    // calculate token amount to be created
+    uint256 tokens = getTokenAmount(weiAmount);
+
+    weiRaised = weiRaised.add(weiAmount);
+
+    if (!token.transferFrom(token.owner(), beneficiary, tokens)) {
+      revert();
+    }
+    TokenPurchase(msg.sender, beneficiary, weiAmount, tokens);
+
+    forwardFunds();
+  }
+
+  /**
+   * @return true if crowdsale event has ended
+   */
+  function hasEnded()
+    public
+    view
+    returns (bool)
+  {
+    bool capReached = weiRaised >= crowdSaleWeiCap;
+    bool endTimeReached =  now >= endTime;
+    return capReached || endTimeReached;
+  }
+
+  /**
+   * @return number of tokens per wei amount
+   */
+  function getTokenAmount(uint256 weiAmount)
+    internal
+    view
+    returns(uint256)
+  {
+    return weiAmount.mul(rate);
+  }
+
+  /**
+   * @dev send ether to the fund collection wallet.
+   */
+  function forwardFunds()
+    internal
+  {
+    wallet.transfer(msg.value);
+  }
+
+
+  /**
+   * @dev Check if potential purchase is valid. We check:
+   *   1. Stage one: purchase amount is whitin crowdsale and personal cap.
+   *   2. Stage two: purchase amount is whiting crwodsale cap and crowdsale hasn't ended yet.
+   * @return true if the transaction can buy tokens
+   */
+  function validPurchase(uint256 weiAmount)
+    internal
+    view
+    returns (bool)
+  {
+    // TODO(luka): we can optimize this but this version is in the most logically deductive order.
+    bool withinCrowdSaleCap = weiRaised.add(weiAmount) <= crowdSaleWeiCap;
+    if (now >= startTimeStageOne && now < startTimeStageTwo) {
+      bool withinPersonalCap = token.balanceOf(msg.sender).div(rate).add(weiAmount) <=
+                                 personalWeiCap;
+      return withinPersonalCap && withinCrowdSaleCap && weiAmount!= 0;
+    }
+    else if (now >= startTimeStageTwo && now < endTime) {
+      return withinCrowdSaleCap && weiAmount != 0;
+    }
+    else {
+      return false;
+    }
+  }
+}

--- a/contracts/crowdsale/XctCrowdsale.sol
+++ b/contracts/crowdsale/XctCrowdsale.sol
@@ -139,7 +139,7 @@ contract XctCrowdsale is Ownable {
    * @return true if crowdsale event has ended
    */
   function hasEnded()
-    public
+    external
     view
     returns (bool)
   {

--- a/contracts/crowdsale/XctCrowdsaleTestable.sol
+++ b/contracts/crowdsale/XctCrowdsaleTestable.sol
@@ -1,0 +1,90 @@
+pragma solidity ^0.4.19;
+
+import "./XctCrowdsale.sol";
+
+
+/**
+  * @title This contract adds additional test functions to the crowdsale contract.
+  * Used to properly test internal functions and contract states which would otherwise be
+  * hard to set up. There are two types of functions; one change contract state and other
+  * visibility of contract functions. Both have their own naming pattern:
+  * 1. Ones that change values of contract variables: `_testSet<variableName>()`.
+  * 2. Ones that change function visibility: `<functionName>Wrapper()`.
+  */
+contract XctCrowdsaleTestable is XctCrowdsale {
+  /**
+   * @dev Tester's address who gains access to super powers.
+   */
+  address public contractTesterAddr;
+
+  /**
+   * @dev check tester's address who is the only one allowed to call _test functions
+   */
+  modifier onlyTester() {
+    require(msg.sender == contractTesterAddr);
+    _;
+  }
+
+  function XctCrowdsaleTestable(uint256 _startTimeStageOne,
+                                uint256 _personalWeiCap,
+                                uint256 _crowdSaleWeiCap,
+                                uint256 _rate,
+                                address _walletAddress,
+                                address _tokenAddress,
+                                address _contractTesterAddr)
+    XctCrowdsale(_startTimeStageOne,
+                 _personalWeiCap,
+                 _crowdSaleWeiCap,
+                 _rate,
+                 _walletAddress,
+                 _tokenAddress)
+    public
+  {
+    contractTesterAddr = _contractTesterAddr;
+  }
+
+  /**
+   * @dev Sets weiRaised value.
+   * @param amount New amount.
+   */
+  function _testSetWeiRaised(uint256 amount)
+    external
+  {
+    weiRaised = amount;
+  }
+
+  /**
+   * @dev Calls internal forwardFunds function.
+   */
+  function forwardFundsWrapper()
+    external
+    payable
+  {
+    super.forwardFunds();
+  }
+
+  /**
+   * @dev Calls internal validPurchase function.
+   * @param weiAmount Wei amount.
+   */
+  function validPurchaseWrapper(uint256 weiAmount)
+    external
+    view
+    returns (bool)
+  {
+    return super.validPurchase(weiAmount);
+  }
+
+  /**
+   * @dev Calls internal getTokenAmount function.
+   * @param weiAmount Wei amount.
+   */
+  function getTokenAmountWrapper(uint256 weiAmount)
+    external
+    view
+    returns (uint256)
+  {
+    return super.getTokenAmount(weiAmount);
+  }
+
+}

--- a/contracts/tokens/Xct.sol
+++ b/contracts/tokens/Xct.sol
@@ -218,6 +218,16 @@ contract Xct is Ownable {
   }
 
   /**
+   * @dev Disables token transfers.
+   */
+  function disableTransfer()
+    onlyOwner()
+    external
+  {
+    transferEnabled = false;
+  }
+
+  /**
    * @dev Burns a specific amount of tokens. Only owner is allowed to perform this operation. This
    * function is based on BurnableToken implementation at goo.gl/GZEhaq.
    * @param _value The amount of token to be burned.

--- a/contracts/tokens/Xct.sol
+++ b/contracts/tokens/Xct.sol
@@ -6,7 +6,7 @@ import "../ownership/Ownable.sol";
 /*
  * @title XCT protocol token.
  * @dev Standard ERC20 token used by the protocol. This contract follows the
- * implementation at https://goo.gl/64yCkF. 
+ * implementation at https://goo.gl/64yCkF.
  */
 contract Xct is Ownable {
   using SafeMath for uint256;
@@ -47,6 +47,11 @@ contract Xct is Ownable {
   bool public transferEnabled;
 
   /**
+   * Crowdsale smart contract address.
+   */
+  address public crowdsaleAddress;
+
+  /**
    * @dev An event which is triggered when funds are transfered.
    * @param _from The address sending tokens.
    * @param _to The address recieving tokens.
@@ -77,6 +82,7 @@ contract Xct is Ownable {
   modifier validDestination(address _to) {
     require(_to != address(0x0));
     require(_to != address(this));
+    require(_to != address(crowdsaleAddress));
     _;
   }
 
@@ -84,7 +90,7 @@ contract Xct is Ownable {
    * @dev Assures that tokens can be transfered.
    */
   modifier onlyWhenTransferAllowed() {
-    require(transferEnabled);
+    require(transferEnabled || msg.sender == crowdsaleAddress);
     _;
   }
 
@@ -245,4 +251,21 @@ contract Xct is Ownable {
     Transfer(owner, address(0x0), _value);
   }
 
+  /**
+    * @dev Set crowdsale address to approve allowance for offering contract to distribute tokens.
+    *
+    * @param crowdsaleAddr Address of token offering contract
+    * @param amount Amount of tokens for the crowdsale.
+    */
+  function setCrowdsaleAllowance(address crowdsaleAddr,
+                                 uint256 amount)
+    external
+    onlyOwner
+  {
+    require(!transferEnabled);
+    require(amount > 0);
+
+    approve(crowdsaleAddr, amount);
+    crowdsaleAddress = crowdsaleAddr;
+  }
 }

--- a/test/crowdsale/XctCrowdsale.test.js
+++ b/test/crowdsale/XctCrowdsale.test.js
@@ -1,0 +1,307 @@
+const assertRevert = require('../helpers/assertRevert');
+const { advanceBlock } = require('../helpers/advanceToBlock');
+const { increaseTime, increaseTimeTo, duration } = require('../helpers/increaseTime');
+const latestTime = require('../helpers/latestTime');
+const ether = require('../helpers/ether');
+
+const BigNumber = web3.BigNumber;
+
+const XctCrowdsale = artifacts.require('./XctCrowdsale.sol');
+const XctCrowdsaleTestable = artifacts.require('./XctCrowdsaleTestable.sol');
+const Xct = artifacts.require('./Xct.sol');
+
+
+contract('crowdsale/XctCrowdsale', (accounts) => {
+  let rate = new BigNumber(1000);
+  let crowdsaleCap = ether(100);
+  let personalCap = ether(5);
+  let crowdsaleOwner = accounts[1];
+  let tokenOwner = accounts[2];
+  let wallet = accounts[3];
+  let buyerOne = accounts[4];
+  let buyerTwo = accounts[5];
+  let _tester = accounts[6];  // tester should never be the default account!
+
+  let firstStageStart;
+  let token;
+  let crowdsale;
+  let secondStageStart;
+  let endTime;
+
+  before(async () => {
+    // Advance to the next block to correctly read time in the solidity "now"
+    // function interpreted by testrpc
+    await advanceBlock();
+  });
+
+  beforeEach(async () => {
+    firstStageStart = latestTime() + duration.hours(1);
+    token = await Xct.new({from: tokenOwner});
+    crowdsale = await XctCrowdsaleTestable.new(firstStageStart,
+                                                    personalCap,
+                                                    crowdsaleCap,
+                                                    rate,
+                                                    wallet,
+                                                    token.address,
+                                                    _tester,
+                                                    {from: crowdsaleOwner});
+    let _secondStageStart = await crowdsale.startTimeStageTwo.call();
+    secondStageStart = _secondStageStart.toNumber();
+    let _endTime = await crowdsale.endTime.call();
+    endTime= _endTime.toNumber();
+  });
+
+  it('time stages should be in the right order', async () => {
+    assert.ok(firstStageStart < secondStageStart < endTime);
+  });
+
+  it('constructor should fail with start time in the past', async () => {
+    firstStageStartPast = latestTime() - duration.weeks(1);
+    await assertRevert(XctCrowdsale.new(firstStageStartPast, 0, crowdsaleCap,
+                                        rate, wallet, token.address));
+  });
+
+  it('constructor should fail with zero personal cap', async () => {
+    await assertRevert(XctCrowdsale.new(firstStageStart, 0, crowdsaleCap,
+                                        rate, wallet, token.address));
+  });
+
+  it('constructor should fail with zero crowdsale cap', async () => {
+    await assertRevert(XctCrowdsale.new(firstStageStart, personalCap, 0,
+                                        rate, wallet, token.address));
+  });
+
+  it('constructor should fail if personalCap > crowdsaleCap', async () => {
+    await assertRevert(XctCrowdsale.new(firstStageStart, ether(100), ether(99),
+                                        rate, wallet, token.address));
+  });
+
+  it('constructor should fail with zero rate', async () => {
+    await assertRevert(XctCrowdsale.new(firstStageStart, personalCap, crowdsaleCap,
+                                        0, wallet, token.address));
+  });
+
+  it('constructor should fail with zero wallet address', async () => {
+    await assertRevert(XctCrowdsale.new(firstStageStart, personalCap, crowdsaleCap,
+                                        rate, 0, token.address));
+  });
+
+  it('constructor should fail with zero token address', async () => {
+    await assertRevert(XctCrowdsale.new(firstStageStart, personalCap, crowdsaleCap,
+                                        rate, wallet, 0));
+  });
+
+  it('constructor should fail if token address == wallet address', async () => {
+    await assertRevert(XctCrowdsale.new(firstStageStart, personalCap, crowdsaleCap,
+                                        rate, wallet, wallet));
+  });
+
+  it('constructor should fail if total supply of token < crowdsale cap', async () => {
+    await assertRevert(XctCrowdsale.new(firstStageStart, personalCap, ether(9999999),
+                                        rate, wallet, token.address));
+  });
+
+  it('constructor should not fail while initializing a valid contract', async () => {
+    await XctCrowdsale.new(firstStageStart, personalCap, crowdsaleCap,
+                           rate, wallet, token.address);
+  });
+
+  it('validPurchase should return false when not yet first stage', async () => {
+    let weiAmount = ether(0.05);
+    assert.strictEqual(await crowdsale.validPurchaseWrapper(weiAmount, {from: buyerOne}),
+                       false);
+  });
+
+  it('validPurchase should return true when first stage and no caps reached', async () => {
+    // Fast forward into the first stage of token sale
+    await increaseTimeTo(firstStageStart + duration.seconds(30));
+    let weiAmount = ether(0.05);
+    assert.strictEqual(await crowdsale.validPurchaseWrapper(weiAmount, {from: buyerOne}),
+                       true);
+  });
+
+  it('validPurchase should return false when first stage and 0 wei sent', async () => {
+    // Fast forward into the first stage of token sale
+    await increaseTimeTo(firstStageStart + duration.minutes(10));
+    assert.strictEqual(await crowdsale.validPurchaseWrapper(0, {from: buyerOne}), false);
+  });
+
+  it('validPurchase should return false when first stage and personal cap reached', async () => {
+    // Set up buyerOne's token balance to be > personal cap for 1st stage
+    await token.enableTransfer({from: tokenOwner});
+    await token.transfer(buyerOne, rate.mul(personalCap), {from: tokenOwner});
+    await token.disableTransfer({from: tokenOwner});
+    // Fast forward into the first stage of token sale
+    await increaseTimeTo(firstStageStart + duration.minutes(10));
+    let weiAmount = ether(1);
+    // 5 + 1 eth > 5 personal cap eth
+    assert.strictEqual(await crowdsale.validPurchaseWrapper(weiAmount, {from: buyerOne}),
+                       false);
+  });
+
+  it('validPurchase should return false when first stage and crowdsale cap reached', async () => {
+    crowdsale._testSetWeiRaised(crowdsaleCap, {from: _tester})
+    // Fast forward into the first stage of token sale
+    await increaseTimeTo(firstStageStart + duration.minutes(10));
+    let weiAmount = ether(1);
+    assert.strictEqual(await crowdsale.validPurchaseWrapper(weiAmount, {from: buyerOne}),
+                       false);
+  });
+
+  it('validPurchase should return true when 2nd stage and crowdsale cap not reached', async () => {
+    // Fast forward into the second stage of token sale
+    await increaseTimeTo(secondStageStart + duration.seconds(10));
+    let weiAmount = personalCap.add(ether(2));
+    assert.strictEqual(await crowdsale.validPurchaseWrapper(weiAmount, {from: buyerTwo}),
+                       true);
+  });
+
+  it('validPurchase should return false when second stage and crowdsale cap reached', async () => {
+    crowdsale._testSetWeiRaised(crowdsaleCap, {from: _tester})
+    // Fast forward into the second stage of token sale
+    await increaseTimeTo(secondStageStart + duration.seconds(30));
+    let weiAmount = personalCap.add(ether(2));
+    assert.strictEqual(await crowdsale.validPurchaseWrapper(weiAmount, {from: buyerTwo}),
+                       false);
+  });
+
+  it('validPurchase should return false when end time reached', async () => {
+    // Fast forward into the end of the token sale
+    await increaseTimeTo(endTime + duration.seconds(30));
+    let weiAmount = ether(0.2);
+    assert.strictEqual(await crowdsale.validPurchaseWrapper(weiAmount, {from: buyerTwo}),
+                       false);
+  });
+
+  it('forwardFunds should send eth to wallet address', async () => {
+    let weiAmount = ether(0.2);
+    let initialBalance = await web3.eth.getBalance(wallet);
+    await crowdsale.forwardFundsWrapper({from: buyerTwo, value: weiAmount});
+    let newBalance = await web3.eth.getBalance(wallet);
+    assert.strictEqual(newBalance.sub(initialBalance).toString(), ether(0.2).toString());
+  });
+
+  it('getTokenAmount should return correct num of tokens for a given wei', async () => {
+    let weiAmount = ether(0.2);
+    let tokensAmount = await crowdsale.getTokenAmountWrapper(weiAmount, {from: buyerTwo});
+    assert.strictEqual(tokensAmount.toString(), weiAmount.mul(rate).toString());
+  });
+
+  it('hasEnded should return false if crowdsale not started, cap not reached', async () => {
+    assert.strictEqual(await crowdsale.hasEnded(), false);
+  });
+
+  it('hasEnded should return false if crowdsale in first stage, cap not reached', async () => {
+    await increaseTimeTo(firstStageStart + duration.seconds(30));
+    assert.strictEqual(await crowdsale.hasEnded(), false);
+  });
+
+  it('hasEnded should return false if crowdsale in second stage, cap not reached', async () => {
+    await increaseTimeTo(secondStageStart + duration.seconds(30));
+    assert.strictEqual(await crowdsale.hasEnded(), false);
+  });
+
+  it('hasEnded should return true if crowdsale has reached end time, cap not reached', async () => {
+    await increaseTimeTo(endTime + duration.seconds(30));
+    assert.strictEqual(await crowdsale.hasEnded(), true);
+  });
+
+  it('hasEnded should return true if crowdsale reached the cap, end time not reached', async () => {
+    crowdsale._testSetWeiRaised(crowdsaleCap, {from: _tester})
+    assert.strictEqual(await crowdsale.hasEnded(), true);
+  });
+
+  it('hasEnded should return true if crowdsale reached the cap and end time', async () => {
+    await increaseTimeTo(endTime + duration.seconds(30));
+    crowdsale._testSetWeiRaised(crowdsaleCap, {from: _tester})
+    assert.strictEqual(await crowdsale.hasEnded(), true);
+  });
+
+  it('buyTokens should purchase tokens', async () => {
+    let weiAmount = ether(0.05);
+    let shouldGetTokens = weiAmount.mul(rate);
+    let startWalletBalance = await web3.eth.getBalance(wallet);
+    await token.setCrowdsaleAllowance(crowdsale.address, crowdsaleCap,
+                                           {from: tokenOwner});
+    await increaseTimeTo(firstStageStart + duration.seconds(30));
+    let { logs } = await crowdsale.buyTokens(buyerOne, {from: buyerOne, value: weiAmount});
+    let actualBalance = await token.balanceOf(buyerOne);
+
+    // Buyer should get correct number of tokens
+    assert.equal(actualBalance.toString(), shouldGetTokens.toString());
+
+    // Wallet should receive correct amount of wei
+    let endWalletBalance = await web3.eth.getBalance(wallet);
+    assert.strictEqual(endWalletBalance.sub(startWalletBalance).toString(), weiAmount.toString());
+
+    // Global counter for raised wei should be increased
+    let weiRaised = await crowdsale.weiRaised.call()
+    assert.strictEqual(weiRaised.toString(), weiAmount.toString());
+
+    let event = logs.find(e => e.event === 'TokenPurchase');
+    assert.notEqual(event, undefined);
+  });
+
+  it('buyTokens should fail purchasing tokens if beneficiary address is 0', async () => {
+    await increaseTimeTo(firstStageStart + duration.seconds(30));
+    await token.setCrowdsaleAllowance(crowdsale.address, crowdsaleCap,
+                                           {from: tokenOwner});
+    await assertRevert(crowdsale.buyTokens(0, {from: buyerOne}));
+  });
+
+  it('buyTokens should fail purchasing tokens if validPurchase returns false', async () => {
+
+    let weiAmount = ether(0.05);
+    await token.setCrowdsaleAllowance(crowdsale.address, crowdsaleCap,
+                                           {from: tokenOwner});
+    // In this case crowdsale hasn't started yet
+    await assertRevert(crowdsale.buyTokens(buyerOne, {from: buyerOne, value: weiAmount}));
+  });
+
+  it('buyTokens should fail purchasing tokens if token transfer fails', async () => {
+    let weiAmount = ether(0.05);
+    await increaseTimeTo(firstStageStart + duration.seconds(30));
+    // Crowdsale contract has zero token allowance
+    await assertRevert(crowdsale.buyTokens(buyerOne, {from: buyerOne, value: weiAmount}));
+  });
+
+  it('fallback function should purchase tokens', async () => {
+    let weiAmount = ether(0.05);
+    let shouldGetTokens = weiAmount.mul(rate);
+    let startWalletBalance = await web3.eth.getBalance(wallet);
+    await token.setCrowdsaleAllowance(crowdsale.address, crowdsaleCap,
+                                           {from: tokenOwner});
+    await increaseTimeTo(firstStageStart + duration.seconds(30));
+    let { logs } = await crowdsale.sendTransaction({from: buyerOne, value: weiAmount});
+    let actualBalance = await token.balanceOf(buyerOne);
+
+    // Buyer should get correct number of tokens
+    assert.equal(actualBalance.toString(), shouldGetTokens.toString());
+
+    // Wallet should receive correct amount of wei
+    let endWalletBalance = await web3.eth.getBalance(wallet);
+    assert.strictEqual(endWalletBalance.sub(startWalletBalance).toString(), weiAmount.toString());
+
+    // Global counter for raised wei should be increased
+    let weiRaised = await crowdsale.weiRaised.call()
+    assert.strictEqual(weiRaised.toString(), weiAmount.toString());
+
+    let event = logs.find(e => e.event === 'TokenPurchase');
+    assert.notEqual(event, undefined);
+  });
+
+  it('fallback function should fail purchasing tokens if validPurchase returns false', async () => {
+    let weiAmount = ether(0.05);
+    await token.setCrowdsaleAllowance(crowdsale.address, crowdsaleCap,
+                                           {from: tokenOwner});
+    // In this case crowdsale hasn't started yet
+    await assertRevert(crowdsale.sendTransaction({from: buyerOne, value: weiAmount}));
+  });
+
+  it('buyTokens should fail purchasing tokens if token transfer fails', async () => {
+    let weiAmount = ether(0.05);
+    await increaseTimeTo(firstStageStart + duration.seconds(30));
+    // Crowdsale contract has zero token allowance
+    await assertRevert(crowdsale.sendTransaction({from: buyerOne, value: weiAmount}));
+  });
+});

--- a/test/helpers/advanceToBlock.js
+++ b/test/helpers/advanceToBlock.js
@@ -1,0 +1,22 @@
+exports.advanceBlock  = function () {
+  return new Promise((resolve, reject) => {
+    web3.currentProvider.sendAsync({
+      jsonrpc: '2.0',
+      method: 'evm_mine',
+      id: Date.now(),
+    }, (err, res) => {
+      return err ? reject(err) : resolve(res);
+    });
+  });
+}
+
+// Advances the block number so that the last mined block is `number`.
+exports.advanceToBlock = async function (number) {
+  if (web3.eth.blockNumber > number) {
+    throw Error(`block number ${number} is in the past (current is ${web3.eth.blockNumber})`);
+  }
+
+  while (web3.eth.blockNumber < number) {
+    await advanceBlock();
+  }
+}

--- a/test/helpers/ether.js
+++ b/test/helpers/ether.js
@@ -1,0 +1,3 @@
+module.exports = function ether (n) {
+  return new web3.BigNumber(web3.toWei(n, 'ether'));
+}

--- a/test/helpers/increaseTime.js
+++ b/test/helpers/increaseTime.js
@@ -1,0 +1,48 @@
+const latestTime = require('./latestTime');
+
+// Increases testrpc time by the passed duration in seconds
+exports.increaseTime = function (duration) {
+  const id = Date.now();
+
+  return new Promise((resolve, reject) => {
+    web3.currentProvider.sendAsync({
+      jsonrpc: '2.0',
+      method: 'evm_increaseTime',
+      params: [duration],
+      id: id,
+    }, err1 => {
+      if (err1) return reject(err1);
+
+      web3.currentProvider.sendAsync({
+        jsonrpc: '2.0',
+        method: 'evm_mine',
+        id: id + 1,
+      }, (err2, res) => {
+        return err2 ? reject(err2) : resolve(res);
+      });
+    });
+  });
+}
+
+/**
+ * Beware that due to the need of calling two separate testrpc methods and rpc calls overhead
+ * it's hard to increase time precisely to a target point so design your test to tolerate
+ * small fluctuations from time to time.
+ *
+ * @param target time in seconds
+ */
+exports.increaseTimeTo = function (target) {
+  let now = latestTime();
+  if (target < now) throw Error(`Cannot increase current time(${now}) to a moment in the past(${target})`);
+  let diff = target - now;
+  return exports.increaseTime(diff);
+}
+
+exports.duration = Object.freeze({
+  seconds: function (val) { return val; },
+  minutes: function (val) { return val * this.seconds(60); },
+  hours: function (val) { return val * this.minutes(60); },
+  days: function (val) { return val * this.hours(24); },
+  weeks: function (val) { return val * this.days(7); },
+  years: function (val) { return val * this.days(365); },
+});

--- a/test/helpers/latestTime.js
+++ b/test/helpers/latestTime.js
@@ -1,0 +1,4 @@
+// Returns the time of the last mined block in seconds
+module.exports = function latestTime () {
+  return web3.eth.getBlock('latest').timestamp;
+}

--- a/test/tokens/Xct.test.js
+++ b/test/tokens/Xct.test.js
@@ -155,4 +155,28 @@ contract('tokens/Xct', (accounts) => {
     await assertRevert(token.burn(totalSupply.plus(1), { from: owner }));
   });
 
+  it('allows only owner to enable transfers', async () => {
+    let transfersState = await token.transferEnabled.call();
+    assert.strictEqual(transfersState, false);
+
+    await token.enableTransfer({ from: owner });
+
+    transfersState = await token.transferEnabled.call();
+    assert.strictEqual(transfersState, true);
+
+    await assertRevert(token.enableTransfer({ from: accounts[1] }));
+  });
+
+  it('allows only owner to disable transfers', async () => {
+    await token.enableTransfer({ from: owner });
+    let transfersState = await token.transferEnabled.call();
+    assert.strictEqual(transfersState, true);
+
+    await token.disableTransfer({ from: owner });
+
+    transfersState = await token.transferEnabled.call();
+    assert.strictEqual(transfersState, false);
+
+    await assertRevert(token.disableTransfer({ from: accounts[1] }));
+  });
 });

--- a/test/tokens/Xct.test.js
+++ b/test/tokens/Xct.test.js
@@ -1,7 +1,7 @@
 const Xct = artifacts.require('./Xct.sol');
 const assertRevert = require('../helpers/assertRevert');
 
-contract('erc/Xct', (accounts) => {
+contract('tokens/Xct', (accounts) => {
   let token;
   let owner = accounts[0];
   let totalSupply = new web3.BigNumber('4e+26');


### PR DESCRIPTION
Relationships between contracts and deployment flow:
1. Crowdsale contract is deployed (needs token address).
1. Token owner sets crowdsale token allowance (needs crowdsale address).
1. Crowdsale starts. There are 2 stages:
    * 1st: runs for a limited amount of time (e.g. 1day) and has per person cap. This enables everybody to participate. No gas war.
    * 2nd: runs after 1st stage, without personal cap. Until hard cap / end time is reached.
1. Collected funds are transferred immediately to the `wallet` address.
1. At the end of the sale token owner manually enables token transfers.

**Some caveats:**
- Truffle testing suite is extremely **fragile**. If tests fail, run them again. At the time of writing this, everything works *most* of the time.
```
  Contract: crowdsale/XctCrowdsale
    ✓ time stages should be in the right order
    ✓ constructor should fail with start time in the past (142ms)
    ✓ constructor should fail with zero personal cap
    ✓ constructor should fail with zero crowdsale cap
    ✓ constructor should fail if personalCap > crowdsaleCap
    ✓ constructor should fail with zero rate
    ✓ constructor should fail with zero wallet address
    ✓ constructor should fail with zero token address (60ms)
    ✓ constructor should fail if token address == wallet address
    ✓ constructor should fail if total supply of token < crowdsale cap
    ✓ constructor should not fail while initializing a valid contract (66ms)
    ✓ validPurchase should return false when not yet first stage
    ✓ validPurchase should return true when first stage and no caps reached (142ms)
    ✓ validPurchase should return false when first stage and 0 wei sent (136ms)
    ✓ validPurchase should return false when first stage and personal cap reached (286ms)
    ✓ validPurchase should return false when first stage and crowdsale cap reached (147ms)
    ✓ validPurchase should return true when 2nd stage and crowdsale cap not reached (132ms)
    ✓ validPurchase should return false when second stage and crowdsale cap reached (147ms)
    ✓ validPurchase should return false when end time reached (132ms)
    ✓ forwardFunds should send eth to wallet address (263ms)
    ✓ getTokenAmount should return correct num of tokens for a given wei
    ✓ hasEnded should return false if crowdsale not started, cap not reached
    ✓ hasEnded should return false if crowdsale in first stage, cap not reached (149ms)
    ✓ hasEnded should return false if crowdsale in second stage, cap not reached (129ms)
    ✓ hasEnded should return true if crowdsale has reached end time, cap not reached (185ms)
    ✓ hasEnded should return true if crowdsale reached the cap, end time not reached (42ms)
    ✓ hasEnded should return true if crowdsale reached the cap and end time (156ms)
    ✓ buyTokens should purchase tokens (470ms)
    ✓ buyTokens should fail purchasing tokens if beneficiary address is 0 (208ms)
    ✓ buyTokens should fail purchasing tokens if validPurchase returns false (54ms)
    ✓ buyTokens should fail purchasing tokens if token transfer fails (154ms)
    ✓ fallback function should purchase tokens (437ms)
    ✓ fallback function should fail purchasing tokens if validPurchase returns false (48ms)
    ✓ buyTokens should fail purchasing tokens if token transfer fails (169ms)


  34 passing (14s)

```
- When playing with time travel in tests, make sure time jumps are large enough. Don't try to test against a particular timestamp (it's going to be off most of the time due to the 2 RPC calls)
- Below are some of the flaky errors which are popping up from time to time:

Testrpc dies in the middle of testing:

```
 Contract: crowdsale/XctCrowdsale "after each" hook: after test for "hasEnded should return false if crowdsale in second stage, cap not reached":
     Error: Could not connect to your Ethereum client. Please check that your Ethereum client:
    - is running
    - is accepting RPC connections (i.e., "--rpc" option is used in geth)
    - is accessible over the network
    - is properly configured in your Truffle configuration file (truffle.js)
```
For some reason account's funds get depleted:
```
Contract: crowdsale/XctCrowdsale validPurchase should return false when first stage and crowdsale cap reached:
     Uncaught Error: Error: sender doesn't have enough funds to send tx. The upfront cost is: 672197500000000000 and the
sender's account only has: 0
```
And most worrying ones are those which run fine but asserts fail:
```
Contract: crowdsale/XctCrowdsale validPurchase should return true when 2nd stage and crowdsale cap not reached:

      AssertionError: expected true to equal false
      + expected - actual

      -true
      +false
```
And:
```
Contract: crowdsale/XctCrowdsale forwardFunds should send eth to wallet address:

      AssertionError: expected '400000000000000000' to equal '200000000000000000'
      + expected - actual

      -400000000000000000
      +200000000000000000
```
I had to go back and forth to properly test this since I couldn't entirely rely on tests. Still, this code needs a proper code review.

@xpepermint @MoMannn 