### PR TITLE
Add 0xcert vesting contract

### DIFF
--- a/contracts/vesting/XctVesting.sol
+++ b/contracts/vesting/XctVesting.sol
@@ -24,8 +24,15 @@ contract XctVesting is Ownable {
 
   // TODO(luka): this is just an approximation.
   uint256 private months = 30 days;
+
+  /**
+   * Number of decimals for vesting rates.
+   */
   uint256 private rateDecimals = 3;
 
+  /**
+   * An array of vesting stages (timestamps).
+   */
   uint256[10] public vestingTimestamps;
 
   mapping(uint256 => uint256[]) public vestingRates;
@@ -40,6 +47,9 @@ contract XctVesting is Ownable {
     Roles role;
   }
 
+  /**
+   * Mapping from an address to a vesting member.
+   */
   mapping(address => Member) public members;
 
   function XctVesting(address _tokenAddress, uint256 _icoStartTime)
@@ -103,6 +113,12 @@ contract XctVesting is Ownable {
     assert(vestingRates[uint(Roles.Advisor)].length == vestingTimestamps.length);
   }
 
+  /**
+   * @dev Add a member to the vesting contract
+   * @param addr Member's address.
+   * @param amount Amount of tokens to vest.
+   * @param role Member's role.
+   */
   function addMember(address addr, uint256 amount, string role)
     onlyOwner()
     external
@@ -127,6 +143,9 @@ contract XctVesting is Ownable {
     return true;
   }
 
+  /**
+   * @dev Withdraw vested tokens.
+   */
   function withdraw()
     external
   {

--- a/contracts/vesting/XctVesting.sol
+++ b/contracts/vesting/XctVesting.sol
@@ -1,0 +1,172 @@
+pragma solidity ^0.4.19;
+
+import "../math/SafeMath.sol";
+import "../tokens/Xct.sol";
+import "../ownership/Ownable.sol";
+
+
+/**
+ * @title XCT vesting contract.
+ * @dev Vesting contract for 0xcert team and advisors.
+ */
+contract XctVesting is Ownable {
+  using SafeMath for uint256;
+
+  /**
+   * XCT Token address.
+   */
+  Xct public token;
+
+  /**
+   * Start timestamp of the token offering. Or do we start at the endTime?
+   */
+  uint256 public icoStartTime;
+
+  // TODO(luka): this is just an approximation.
+  uint256 private months = 30 days;
+  uint256 private rateDecimals = 3;
+
+  uint256[10] public vestingTimestamps;
+
+  mapping(uint256 => uint256[]) public vestingRates;
+
+  enum Roles {Founder, Team, Advisor}
+
+  struct Member {
+    address addr;
+    uint256 totalAmount;
+    uint256 remainingAmount;
+    uint256 atStage;
+    Roles role;
+  }
+
+  mapping(address => Member) public members;
+
+  function XctVesting(address _tokenAddress, uint256 _icoStartTime)
+    public
+  {
+    require(_tokenAddress != address(0));
+    require(_icoStartTime > 0);
+
+    token = Xct(_tokenAddress);
+    icoStartTime = _icoStartTime;
+
+    vestingTimestamps[0] = icoStartTime;
+    vestingTimestamps[1] = icoStartTime + 3 * months;
+    vestingTimestamps[2] = icoStartTime + 6 * months;
+    vestingTimestamps[3] = icoStartTime + 9 * months;
+    vestingTimestamps[4] = icoStartTime + 12 * months;
+    vestingTimestamps[5] = icoStartTime + 15 * months;
+    vestingTimestamps[6] = icoStartTime + 18 * months;
+    vestingTimestamps[7] = icoStartTime + 21 * months;
+    vestingTimestamps[8] = icoStartTime + 24 * months;
+    vestingTimestamps[9] = icoStartTime.add(months.mul(27));
+
+    // 125 / (10 ** rateDecimals) = 0.125 (12.5%)
+    vestingRates[uint(Roles.Founder)] = new uint256[](10);
+    vestingRates[uint(Roles.Founder)][0] = 0;    // ICO
+    vestingRates[uint(Roles.Founder)][1] = 0;    // 3 months
+    vestingRates[uint(Roles.Founder)][2] = 125;  // 6 months
+    vestingRates[uint(Roles.Founder)][3] = 125;  // 9 months
+    vestingRates[uint(Roles.Founder)][4] = 125;  // 12 months
+    vestingRates[uint(Roles.Founder)][5] = 125;  // 15 months
+    vestingRates[uint(Roles.Founder)][6] = 125;  // 18 months
+    vestingRates[uint(Roles.Founder)][7] = 125;  // 21 months
+    vestingRates[uint(Roles.Founder)][8] = 125;  // 24 months
+    vestingRates[uint(Roles.Founder)][9] = 125;  // 27 months
+    assert(vestingRates[uint(Roles.Founder)].length == vestingTimestamps.length);
+
+    vestingRates[uint(Roles.Team)] = new uint256[](10);
+    vestingRates[uint(Roles.Team)][0] = 200;   // ICO
+    vestingRates[uint(Roles.Team)][1] = 150;  // 3 months
+    vestingRates[uint(Roles.Team)][2] = 150;  // 6 months
+    vestingRates[uint(Roles.Team)][3] = 150;  // 9 months
+    vestingRates[uint(Roles.Team)][4] = 150;  // 12 months
+    vestingRates[uint(Roles.Team)][5] = 150;  // 15 months
+    vestingRates[uint(Roles.Team)][6] = 150;  // 18 months
+    vestingRates[uint(Roles.Team)][7] = 50;  // 21 months
+    vestingRates[uint(Roles.Team)][8] = 0;   // 24 months
+    vestingRates[uint(Roles.Team)][9] = 0;   // 27 months
+    assert(vestingRates[uint(Roles.Team)].length == vestingTimestamps.length);
+
+    vestingRates[uint(Roles.Advisor)] = new uint256[](10);
+    vestingRates[uint(Roles.Advisor)][0] = 200;  // ICO
+    vestingRates[uint(Roles.Advisor)][1] = 400;  // 3 months
+    vestingRates[uint(Roles.Advisor)][2] = 400;  // 6 months
+    vestingRates[uint(Roles.Advisor)][3] = 0;  // 9 months
+    vestingRates[uint(Roles.Advisor)][4] = 0;  // 12 months
+    vestingRates[uint(Roles.Advisor)][5] = 0;  // 15 months
+    vestingRates[uint(Roles.Advisor)][6] = 0;  // 18 months
+    vestingRates[uint(Roles.Advisor)][7] = 0;  // 21 months
+    vestingRates[uint(Roles.Advisor)][8] = 0;  // 24 months
+    vestingRates[uint(Roles.Advisor)][9] = 0;  // 27 months
+    assert(vestingRates[uint(Roles.Advisor)].length == vestingTimestamps.length);
+  }
+
+  function addMember(address addr, uint256 amount, string role)
+    onlyOwner()
+    external
+    returns (bool)
+  {
+    require(addr != members[addr].addr);
+    require(addr != address(0));
+    require(amount > 0);
+
+    if (keccak256(role) == keccak256("Founder")) {
+      members[addr] = Member(addr, amount, amount, 0, Roles.Founder);
+    }
+    else if (keccak256(role) == keccak256("Team")) {
+      members[addr] = Member(addr, amount, amount, 0, Roles.Team);
+    }
+    else if (keccak256(role) == keccak256("Advisor")) {
+      members[addr] = Member(addr, amount, amount, 0, Roles.Advisor);
+    }
+    else {
+      revert();
+    }
+    return true;
+  }
+
+  function withdraw()
+    external
+  {
+    Member memory beneficiary = members[msg.sender];
+    require(msg.sender == beneficiary.addr);
+    require(beneficiary.remainingAmount > 0);
+
+    uint256 role = uint256(beneficiary.role);
+    uint256 currentStage = beneficiary.atStage;
+    beneficiary.atStage += 1;
+
+    assert(currentStage < vestingRates[role].length);
+    assert(currentStage < vestingTimestamps.length);
+
+    uint256 currentRate = vestingRates[role][currentStage];
+    require(now >= vestingTimestamps[currentStage]);
+
+    // if vestingRate == 0, then move currentStage forward if you can
+    while (currentStage < vestingRates[role].length && currentRate == 0 && now >= vestingTimestamps[currentStage]) {
+      currentStage = beneficiary.atStage;
+      beneficiary.atStage += 1;
+      currentRate = vestingRates[role][currentStage];
+    }
+
+    // TODO(luka): we could save beneficiary state before we revert to avoid repeating while loops
+    // in the future.
+    require(currentRate > 0);
+
+    bool isLastStage = currentStage == vestingTimestamps.length - 1;
+    uint256 tokensToWithdraw;
+    // Withdraw the remainder which could include truncated quotients from previous divisions.
+    if (isLastStage) {
+      tokensToWithdraw = beneficiary.remainingAmount;
+    }
+    else {
+      tokensToWithdraw = beneficiary.totalAmount.mul(currentRate).div(10 ** rateDecimals);
+    }
+
+    beneficiary.remainingAmount -= tokensToWithdraw;
+    members[msg.sender] = beneficiary;
+    token.transferFrom(token.owner(), beneficiary.addr, tokensToWithdraw);
+  }
+}

--- a/contracts/vesting/XctVesting.sol
+++ b/contracts/vesting/XctVesting.sol
@@ -170,17 +170,17 @@ contract XctVesting is Ownable {
       currentRate = vestingRates[role][currentStage];
     }
 
-    // TODO(luka): we could save beneficiary state before we revert to avoid repeating while loops
-    // in the future.
-    require(currentRate > 0);
-
     bool isLastStage = currentStage == vestingTimestamps.length - 1;
     uint256 tokensToWithdraw;
     // Withdraw the remainder which could include truncated quotients from previous divisions.
     if (isLastStage) {
+      require(beneficiary.remainingAmount > 0);
       tokensToWithdraw = beneficiary.remainingAmount;
     }
     else {
+      // TODO(luka): we could save beneficiary state before we revert to avoid repeating while loops
+      // in the future.
+      require(currentRate > 0);
       tokensToWithdraw = beneficiary.totalAmount.mul(currentRate).div(10 ** rateDecimals);
     }
 

--- a/test/vesting/XctVesting.test.js
+++ b/test/vesting/XctVesting.test.js
@@ -1,0 +1,176 @@
+const assertRevert = require('../helpers/assertRevert');
+const { advanceBlock } = require('../helpers/advanceToBlock');
+const { increaseTime, increaseTimeTo, duration } = require('../helpers/increaseTime');
+const latestTime = require('../helpers/latestTime');
+const ether = require('../helpers/ether');
+
+const BigNumber = web3.BigNumber;
+
+const XctVesting = artifacts.require('./XctVesting.sol');
+const Xct = artifacts.require('./Xct.sol');
+
+
+contract('vesting/XctVesting', (accounts) => {
+  let vestingOwner = accounts[1];
+  let tokenOwner = accounts[2];
+  let founder = accounts[4];
+  let team = accounts[5];
+  let advisor = accounts[6];
+
+  let icoStartTime;
+  let token;
+  let vesting;
+
+  before(async () => {
+    // Advance to the next block to correctly read time in the solidity "now"
+    // function interpreted by testrpc
+    await advanceBlock();
+  });
+
+  beforeEach(async () => {
+    icoStartTime = latestTime() + duration.hours(1);
+    token = await Xct.new({from: tokenOwner});
+    vesting = await XctVesting.new(token.address, icoStartTime, {from: vestingOwner});
+    await token.approve(vesting.address, 1000, {from: tokenOwner});
+    // TODO(luka): we enable transfers for tests. Otherwise we need to add
+    // vesting address to token `onlyWhenTransferAllowed` modifier in order to transfer tokens
+    // during the ICO. If we can do it after the ICO, then fine because we'll unlock transfers
+    // for everyone.
+    await token.enableTransfer({from: tokenOwner});
+  });
+
+  it('constructor should fail with zero token address', async () => {
+    await assertRevert(XctVesting.new(0, icoStartTime));
+  });
+
+  it('constructor should fail with zero ico start time', async () => {
+    await assertRevert(XctVesting.new(token.address, 0));
+  });
+
+  it('constructor initialize expected variables', async () => {
+    let tokenAddr = await vesting.token.call();
+    assert.strictEqual(tokenAddr.toString(), token.address);
+
+    let actualIcoStartTime = await vesting.icoStartTime.call();
+    assert.strictEqual(actualIcoStartTime.toString(), icoStartTime.toString());
+
+    let firstVestingTs = await vesting.vestingTimestamps.call(0);
+    assert.strictEqual(firstVestingTs.toString(), icoStartTime.toString());
+
+    let lastVestingTs = await vesting.vestingTimestamps.call(9);
+    assert.strictEqual(lastVestingTs.toString(), (icoStartTime + duration.days(27 * 30)).toString());
+  });
+
+  it('addMember should add a founder', async () => {
+    await vesting.addMember(founder, 100, "Founder", {from: vestingOwner});
+    let actualFounder = await vesting.members.call(founder);
+    assert.strictEqual(actualFounder[0], founder); // address
+    assert.strictEqual(actualFounder[1].toString(), "100"); // totalAmount
+    assert.strictEqual(actualFounder[2].toString(), "100"); // remainingAmount
+    assert.strictEqual(actualFounder[3].toString(), "0"); // stageAt
+    assert.strictEqual(actualFounder[4].toString(), "0"); // 0 is Founder
+  });
+
+  it('addMember should add a team member', async () => {
+    await vesting.addMember(team, 100, "Team", {from: vestingOwner});
+    let actualTeam = await vesting.members.call(team);
+    assert.strictEqual(actualTeam[0], team);
+    assert.strictEqual(actualTeam[1].toString(), "100"); // totalAmount
+    assert.strictEqual(actualTeam[2].toString(), "100"); // remainingAmount
+    assert.strictEqual(actualTeam[3].toString(), "0"); // stageAt
+    assert.strictEqual(actualTeam[4].toString(), "1"); // 1 is Team
+  });
+
+  it('addMember should add an advisor', async () => {
+    await vesting.addMember(advisor, 100, "Advisor", {from: vestingOwner});
+    let actualAdvisor = await vesting.members.call(advisor);
+    assert.strictEqual(actualAdvisor[0], advisor);
+    assert.strictEqual(actualAdvisor[1].toString(), "100"); // totalAmount
+    assert.strictEqual(actualAdvisor[2].toString(), "100"); // remainingAmount
+    assert.strictEqual(actualAdvisor[3].toString(), "0"); // stageAt
+    assert.strictEqual(actualAdvisor[4].toString(), "2"); // 2 is Advisor
+  });
+
+  it('addMember should not add an unknown member type', async () => {
+    await assertRevert(vesting.addMember(advisor, 100, "Foo", {from: vestingOwner}));
+  });
+
+  it('addMember should not add a member type if not called by owner', async () => {
+    await assertRevert(vesting.addMember(advisor, 100, "Foo", {from: advisor}));
+  });
+
+  it('withdraw should withdraw tokens at ICO time / first stage for team member', async () => {
+    let firstBalance = await token.balanceOf(team);
+    assert.strictEqual(firstBalance.toString(), "0");
+
+    await vesting.addMember(team, 100, "Team", {from: vestingOwner});
+    await increaseTimeTo(icoStartTime + duration.seconds(30));
+    await vesting.withdraw({from: team});
+
+    let secondBalance = await token.balanceOf(team);
+    assert.strictEqual(secondBalance.toString(), "20");
+  });
+
+  it('withdraw should only allow one withdrawal per vesting period', async () => {
+    await vesting.addMember(team, 100, "Team", {from: vestingOwner});
+    await increaseTimeTo(icoStartTime + duration.seconds(30));
+    await vesting.withdraw({from: team});
+    await assertRevert(vesting.withdraw({from: team}));
+  });
+
+  it('withdraw should not allow one withdrawal for non-vesting members', async () => {
+    await increaseTimeTo(icoStartTime + duration.seconds(30));
+    await assertRevert(vesting.withdraw({from: team}));
+  });
+
+  it('withdraw should withdraw tokens for founder at the 3rd vesting stage', async () => {
+    let firstBalance = await token.balanceOf(founder);
+    assert.strictEqual(firstBalance.toString(), "0");
+
+    await vesting.addMember(founder, 50, "Founder", {from: vestingOwner});
+    let actualFounder = await vesting.members.call(founder);
+    assert.strictEqual(actualFounder[3].toString(), "0");
+
+    // Six months + 1 month - available 12.5%
+    await increaseTimeTo(icoStartTime + duration.days(30 * 7));
+
+    await vesting.withdraw({from: founder});
+    actualFounder = await vesting.members.call(founder);
+    assert.strictEqual(actualFounder[3].toString(), "3");
+    currentBalance = await token.balanceOf(founder);
+    assert.strictEqual(currentBalance.toString(), "6");
+
+    actualFounder = await vesting.members.call(founder);
+    assert.strictEqual(actualFounder[2].toString(), "44"); // Remainig amount
+  });
+
+  it('withdraw should withdraw all tokens for advisor', async () => {
+    let firstBalance = await token.balanceOf(advisor);
+    assert.strictEqual(firstBalance.toString(), "0");
+
+    await vesting.addMember(advisor, 60, "Advisor", {from: vestingOwner});
+
+    // Clear all vesting periods
+    await increaseTimeTo(icoStartTime + duration.days(30 * 28));
+
+    // We can withdraw per vesting period - 1st period w/ 20% tokens
+    await vesting.withdraw({from: advisor});
+    currentBalance = await token.balanceOf(advisor);
+    assert.strictEqual(currentBalance.toString(), "12");
+
+    // We can withdraw per vesting period - 2nd period w/ % tokens
+    await vesting.withdraw({from: advisor});
+    currentBalance = await token.balanceOf(advisor);
+    assert.strictEqual(currentBalance.toString(), "36");
+
+    // We can withdraw per vesting period - 3rd  period w/ % tokens
+    await vesting.withdraw({from: advisor});
+    currentBalance = await token.balanceOf(advisor);
+    assert.strictEqual(currentBalance.toString(), "60");
+
+    actualAdvisor = await vesting.members.call(advisor);
+    assert.strictEqual(actualAdvisor[2].toString(), "0"); // Remainig amount
+
+    await assertRevert(vesting.withdraw({from: advisor}));
+  });
+});


### PR DESCRIPTION
*I wanted to open this one when https://github.com/0xcert/ethereum/pull/5 gets in, but since I already have the code, here it is. Unfortunately I had to branch off https://github.com/0xcert/ethereum/pull/5 to keep it clean and have access to some helper functions.*

This contract sets up vesting periods for founders, team members and advisors. 

To discuss:
- vesting periods are measured in approximate months which should probably be changed to days or weeks;
- current vesting start timestamp is ICO's start ts. Even though tokens are still locked until the end of the ICO period (when token transfers become available for everyone).


